### PR TITLE
Fix regex to ignore data-uris

### DIFF
--- a/lib/parse-imports.js
+++ b/lib/parse-imports.js
@@ -83,7 +83,7 @@ module.exports = function (filename, content, config) {
 
     // if resolveUrls is set then resolve the urls to a specific baseUrl
     if (config.resolveUrls) {
-      return source.replace(/url\s*\(\s*(['"]?)([^"'\)]*)\1\s*\)/gi, function (m, q, url) {
+      return source.replace(/url\s*\(\s*(['"]?)((?!\s*data:)[^"'\)]*)\1\s*\)/gi, function (m, q, url) {
         var relUrl = resolveUrl(url, config.baseUrl || basePath, config.context);
 
         var id = result.urls.indexOf(relUrl);


### PR DESCRIPTION
I found a bug where this loader was incorrectly trying to resolve `url: ('data:image...)` sections. This should fix it. Here's some testing I did with the new regex:

![image](https://cloud.githubusercontent.com/assets/3290587/20850942/8c45a744-b892-11e6-8eb5-2907cd5fbea0.png)
